### PR TITLE
add support for 0x048d:0x6006

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following devices have been reported to work:
 | idVendor | idProduct | bcdDevice |                vendor                |      product      |
 |----------|-----------|-----------|--------------------------------------|-------------------|
 | 048d     | 6004      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
+| 048d     | 6006      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
 | 048d     | ce00      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
 
 You can use `lsusb` to determine if a compatible device is found on your system. If you believe your device should be supported, but it is not, please open an issue.

--- a/hid-ite8291r3.c
+++ b/hid-ite8291r3.c
@@ -558,6 +558,7 @@ static void ite8291r3_remove(struct hid_device *hdev)
 
 static const struct hid_device_id ite8291r3_device_ids[] = {
 	{ HID_USB_DEVICE(USB_VENDOR_ID_ITE, 0x6004) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_ITE, 0x6006) },
 	{ HID_USB_DEVICE(USB_VENDOR_ID_ITE, 0xce00) },
 	{ },
 };


### PR DESCRIPTION
The 0x048d:0x6006 device appears to work fine on Intel NUC X15 machines, so add it to the list of supported products.

https://github.com/pobrn/ite8291r3-ctl/pull/16